### PR TITLE
Potential fix for code scanning alert no. 5: Uncontrolled data used in path expression

### DIFF
--- a/app.py
+++ b/app.py
@@ -353,7 +353,11 @@ def upload_file():
         return redirect(request.url)
     
     file = request.files['file']
+    allowed_curriculum_types = ['ap_cs_a', 'ap_cs_principles']
     curriculum_type = request.form.get('curriculum_type', 'ap_cs_a')
+    if curriculum_type not in allowed_curriculum_types:
+        flash('Invalid curriculum type')
+        return redirect(request.url)
     
     if file.filename == '':
         flash('No selected file')


### PR DESCRIPTION
Potential fix for [https://github.com/ndweir/MN-CSTA-apCS-agent/security/code-scanning/5](https://github.com/ndweir/MN-CSTA-apCS-agent/security/code-scanning/5)

To fix the problem, we need to ensure that the `curriculum_type` value is validated before it is used to construct the file path. One way to do this is to restrict the `curriculum_type` to a predefined set of allowed values. This will prevent any malicious input from being used in the path construction.

1. Define a list of allowed curriculum types.
2. Check if the provided `curriculum_type` is in the list of allowed values.
3. If it is not, return an error message.
4. If it is, proceed with the file saving process.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
