### PR TITLE
Potential fix for code scanning alert no. 4: Flask app is run in debug mode

### DIFF
--- a/app.py
+++ b/app.py
@@ -546,5 +546,6 @@ except Exception as e:
 
 if __name__ == '__main__':
     # Use this for local development
-    app.run(debug=True, port=5001)
+    debug_mode = os.getenv('FLASK_DEBUG', 'False').lower() in ['true', '1', 't']
+    app.run(debug=debug_mode, port=5001)
 # For production on PythonAnywhere, the WSGI file will import the 'app' variable


### PR DESCRIPTION
Potential fix for [https://github.com/ndweir/MN-CSTA-apCS-agent/security/code-scanning/4](https://github.com/ndweir/MN-CSTA-apCS-agent/security/code-scanning/4)

To fix the problem, we need to ensure that the Flask application does not run in debug mode in a production environment. The best way to achieve this is by using an environment variable to control the debug mode. This way, we can set the debug mode to `True` for local development and `False` for production.

We will modify the `app.run` call to check the value of an environment variable (e.g., `FLASK_DEBUG`) to determine whether to enable debug mode. This change will be made in the `app.py` file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
