### PR TITLE
Potential fix for code scanning alert no. 5: Uncontrolled data used in path expression

### DIFF
--- a/app.py
+++ b/app.py
@@ -365,7 +365,10 @@ def upload_file():
     
     if file and allowed_file(file.filename):
         filename = secure_filename(file.filename)
-        save_path = os.path.join(app.config['UPLOAD_FOLDER'], curriculum_type, filename)
+        save_path = os.path.normpath(os.path.join(app.config['UPLOAD_FOLDER'], curriculum_type, filename))
+        if not save_path.startswith(os.path.normpath(app.config['UPLOAD_FOLDER'])):
+            flash('Invalid file path')
+            return redirect(request.url)
         file.save(save_path)
         
         # Reload curriculum data


### PR DESCRIPTION
Potential fix for [https://github.com/ndweir/MN-CSTA-apCS-agent/security/code-scanning/5](https://github.com/ndweir/MN-CSTA-apCS-agent/security/code-scanning/5)

To fix the problem, we need to ensure that the constructed file path is contained within a safe root folder. This can be achieved by normalizing the path using `os.path.normpath` and then verifying that the normalized path starts with the intended root directory. This will prevent directory traversal attacks and ensure that the file is saved in the correct location.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
